### PR TITLE
Add Facebook Icon to Footer

### DIFF
--- a/components/src/components/Footer/index.tsx
+++ b/components/src/components/Footer/index.tsx
@@ -1,4 +1,6 @@
 import { LogoSVG } from '../Icons/LogoSVG';
+import { FacebookSVG } from '../Icons/FacebookSVG';
+
 import { discordLink } from '../discordLink';
 import './styles.scss';
 export const Footer = () => {
@@ -32,6 +34,13 @@ export const Footer = () => {
           <a href="https://twitter.com/viz_hub">Twitter</a>
           <a href="https://www.youtube.com/@currankelleher">
             YouTube
+          </a>
+          <a
+            href="/https://www.facebook.com/profile.php?id=100071381815409"
+            target="_blank"
+          >
+            <FacebookSVG />
+            <span>Facebook</span>
           </a>
         </div>
       </div>

--- a/components/src/components/Footer/styles.scss
+++ b/components/src/components/Footer/styles.scss
@@ -41,6 +41,7 @@
         text-decoration: none;
         color: white;
       }
+     
     }
   }
 }


### PR DESCRIPTION
This pull request adds a Facebook icon to the footer, linking to our official page. 

Testing:
1.  Check the footer on the homepage for the Facebook icon.
2. Verify the link opens our Facebook page in a new tab.
3. Check responses to various device sizes.

Feedback and suggestions are welcome!