### PR TITLE
Clear out README on fork

### DIFF
--- a/interactors/src/forkViz.ts
+++ b/interactors/src/forkViz.ts
@@ -163,6 +163,24 @@ export const ForkViz = (gateways: Gateways) => {
       id: newVizId,
     };
 
+    // Remove the README, since literally no one updates it anyway,
+    // and the old README in modified vizzes is often outdated
+    // and just doesn't make sense, especially the ones with the videos.
+    newContent.files = Object.keys(oldContent.files).reduce(
+      (acc, fileId) => {
+        if (oldContent.files[fileId].name === 'README.md') {
+          acc[fileId] = {
+            name: 'README.md',
+            text: '',
+          };
+        } else {
+          acc[fileId] = oldContent.files[fileId];
+        }
+        return acc;
+      },
+      {},
+    );
+
     const newCommit: Commit = {
       id: commitId,
       parent: parentCommitId,


### PR DESCRIPTION
I've noticed that literally no one updates the README after forking and modifying. So I figure let's delete the README content when you fork. 

This change makes it so the README content gets cleared out after forking.