### PR TITLE
Add current story to URL

### DIFF
--- a/components/src/KitchenSinkApp.tsx
+++ b/components/src/KitchenSinkApp.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import './App.scss';
 import './stories/stories.css';
 import { Sidebar } from './Sidebar';
@@ -23,8 +23,32 @@ const entries = Object.keys(stories)
 const entriesMap = new Map(entries.map((d) => [d.key, d]));
 
 export const KitchenSinkApp = () => {
-  const [storyKey, setStoryKey] = useState(null);
+  // Get initial story from URL
+  const getStoryFromURL = () => {
+    const params = new URLSearchParams(
+      window.location.search,
+    );
+    return params.get('story');
+  };
+
+  const [storyKey, setStoryKey] = useState(
+    getStoryFromURL(),
+  );
   const [showSidebar, setShowSidebar] = useState(true);
+
+  // Update URL when story changes
+  useEffect(() => {
+    const params = new URLSearchParams(
+      window.location.search,
+    );
+    if (storyKey) {
+      params.set('story', storyKey);
+    } else {
+      params.delete('story');
+    }
+    const newURL = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState({}, '', newURL);
+  }, [storyKey]);
   const Component = storyKey
     ? entriesMap.get(storyKey).component
     : null;


### PR DESCRIPTION
Fixes some usability issues I noticed when @nitanagdeote was working on components.

After this change, the selected story is "remembered" across page refreshes, so you don't need to click into the same thing again and again.